### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Here is a showcase of all possible field attributes:
     use custom_debug::Debug;
     use std::fmt;
 
-    #[deriveDebug)]
+    #[derive(Debug)]
     struct Foo {
         #[debug(format = "{} things")]
         x: i32,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/custom_debug/14)
<!-- Reviewable:end -->
