### PR TITLE
Basic GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,67 @@
+---
+name: CI checks
+
+on:
+  workflow_dispatch:
+    inputs:
+      source:
+        description: Source ref used to build bindings. Uses `github.ref`` by default.
+        required: false
+      sha:
+        description: Source SHA used to build bindings. Uses `github.sha`` by default.
+        required: false
+
+  push:
+    branches:
+    - main
+    paths:
+    - Cargo.toml
+    - Cargo.lock
+    - src/**
+    - tests/**
+    - .github/workflows/ci.yaml
+  pull_request:
+    paths:
+    - Cargo.toml
+    - Cargo.lock
+    - src/**
+    - tests/**
+    - .github/workflows/ci.yaml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  COLOR: yes
+  FORCE_COLOR: 1
+  CARGO_TERM_COLOR: always
+  CARGO_TERM_PROGRESS_WHEN: never
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+  CARGO_NET_RETRY: 10
+  BINSTALL_DISABLE_TELEMETRY: true
+
+permissions: {}
+jobs:
+  ci-build:
+    name: Build and test
+
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+    steps:
+    - name: Rust version
+      run: |
+        rustc --version
+        cargo --version
+
+    - name: Checkout repo
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.inputs.source || github.ref || github.event.ref }}
+
+    - name: Run tests
+      run: |
+        cargo test --all

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,69 @@
+---
+name: Release crate
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  COLOR: yes
+  FORCE_COLOR: 1
+  CARGO_TERM_COLOR: always
+  CARGO_TERM_PROGRESS_WHEN: never
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+  CARGO_NET_RETRY: 10
+
+jobs:
+  build:
+    permissions:
+      contents: read
+    if: ${{ github.ref == 'refs/heads/main' }}
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Rust version
+      run: |
+        rustc --version
+        cargo --version
+
+    - name: Checkout repo
+      uses: actions/checkout@v6
+
+    - name: Run tests
+      run: |
+        cargo test --all
+
+    - name: Verify publishing
+      run: cargo publish --dry-run
+
+  publish-github:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v6
+    - name: Publish github
+      run: |
+        package_version=$(cargo metadata --format-version 1 --no-deps| jq -r '.packages[] | select(.name=="custom_debug") .version')
+        gh release create "v${package_version}" --fail-on-no-commits --generate-notes --latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-cargo:
+    runs-on: ubuntu-latest
+    needs: publish-github
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v6
+    - name: Package
+      run: cargo publish --no-verify
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Basic CI & release GitHub actions, adjust as needed. Require some testing (I usually do it in private fork).

to release it's requires to set `CARGO_REGISTRY_TOKEN` . 

In my repos I also plan to publish Immutable releases on GitHub as well. 

Solves #30

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/custom_debug/32)
<!-- Reviewable:end -->
